### PR TITLE
Fix Aliscore/ALICUT download path and Perl module include path

### DIFF
--- a/phylo_from_buscos/SKILL.md
+++ b/phylo_from_buscos/SKILL.md
@@ -182,7 +182,7 @@ if [ "${SCRIPT_CHOICE}" = "1" ]; then
     echo "Using predownloaded Aliscore/ALICUT scripts..."
 
     # Download predownloaded scripts from GitHub repository
-    GITHUB_BASE="https://github.com/brunoasm/my_claude_skills/raw/main/phylo_from_buscos/scripts/predownloaded_aliscore_alicut"
+    GITHUB_BASE="https://raw.githubusercontent.com/brunoasm/my_claude_skills/main/phylo_from_buscos/scripts/predownloaded_aliscore_alicut"
     if wget -q "${GITHUB_BASE}/Aliscore.02.2.pl" -O scripts/Aliscore.02.2.pl && \
        wget -q "${GITHUB_BASE}/ALICUT_V2.31.pl" -O scripts/ALICUT_V2.31.pl && \
        wget -q "${GITHUB_BASE}/Aliscore_module.pm" -O scripts/Aliscore_module.pm; then

--- a/phylo_from_buscos/scripts/run_aliscore.sh
+++ b/phylo_from_buscos/scripts/run_aliscore.sh
@@ -205,7 +205,7 @@ echo "Options: ${ALISCORE_OPTS}"
 echo "Aliscore script: ${ALISCORE_SCRIPT}"
 
 # Construct and run Aliscore command
-ALISCORE_CMD="perl ${ALISCORE_SCRIPT} -i $(basename ${ALIGNMENT}) ${ALISCORE_OPTS}"
+ALISCORE_CMD="perl -I${SCRIPT_DIR} ${ALISCORE_SCRIPT} -i $(basename ${ALIGNMENT}) ${ALISCORE_OPTS}"
 echo "Command: ${ALISCORE_CMD}"
 
 eval ${ALISCORE_CMD}


### PR DESCRIPTION
This commit addresses two critical issues preventing Aliscore/ALICUT from running:

1. Fixed download instructions in SKILL.md to use correct raw GitHub URLs
   - Changed from: https://github.com/...../raw/main/...
   - Changed to: https://raw.githubusercontent.com/...../main/...
   - The previous URL format downloaded HTML instead of actual Perl scripts

2. Fixed Perl module path in run_aliscore.sh
   - Added -I${SCRIPT_DIR} to Perl command at line 208
   - This ensures Perl can locate Aliscore_module.pm regardless of working directory
   - The script changes to output directory before running, so explicit include path needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)