### PR TITLE
Organize Aliscore outputs into dedicated aliscore_output directory

### DIFF
--- a/phylo_from_buscos/REFERENCE.md
+++ b/phylo_from_buscos/REFERENCE.md
@@ -445,7 +445,7 @@ After running Aliscore + ALICUT, evaluate trimming statistics:
 cat trimmed_aa/trimming_summary.txt
 
 # Check specific locus
-cd aliscore_[locus]
+cd aliscore_output/aliscore_[locus]
 cat ALICUT_info.xls
 ```
 
@@ -462,7 +462,7 @@ cat ALICUT_info.xls
 For RNA secondary structure alignments, preserves paired stem positions.
 
 ```bash
-bash scripts/run_alicut.sh aliscore_16S/ -r -s
+bash scripts/run_alicut.sh aliscore_output/aliscore_16S/ -r -s
 ```
 
 **When to use:** rRNA genes (16S, 18S, 28S) with structure annotation
@@ -473,7 +473,7 @@ Translates amino acid RSS positions to nucleotide triplets (back-translation).
 
 ```bash
 # After running Aliscore on protein alignment
-bash scripts/run_alicut.sh aliscore_protein/ -c -s
+bash scripts/run_alicut.sh aliscore_output/aliscore_protein/ -c -s
 ```
 
 **When to use:**
@@ -485,7 +485,7 @@ bash scripts/run_alicut.sh aliscore_protein/ -c -s
 Removes only 3rd codon positions of identified RSS.
 
 ```bash
-bash scripts/run_alicut.sh aliscore_protein/ -c -3 -s
+bash scripts/run_alicut.sh aliscore_output/aliscore_protein/ -c -3 -s
 ```
 
 **When to use:**
@@ -514,7 +514,7 @@ ls *.fas > locus_list.txt
 # Submit array job (see SKILL.md for templates)
 
 # Step 2: After Aliscore completes, batch process ALICUT
-for dir in aliscore_*/; do
+for dir in aliscore_output/aliscore_*/; do
     bash ../scripts/run_alicut.sh "${dir}" -s
 done
 ```
@@ -540,7 +540,7 @@ For critical loci, view the SVG plots:
 
 ```bash
 # Open in browser
-firefox aliscore_[locus]/*svg
+firefox aliscore_output/aliscore_[locus]/*svg
 ```
 
 Look for:

--- a/phylo_from_buscos/SKILL.md
+++ b/phylo_from_buscos/SKILL.md
@@ -929,13 +929,13 @@ After all Aliscore jobs complete:
 
 ```bash
 # Step 2: ALICUT array job or batch processing
-for dir in aliscore_*/; do
+for dir in aliscore_output/aliscore_*/; do
     bash ../scripts/run_alicut.sh "${dir}" -s
 done
 
 # Collect trimmed alignments
 mkdir -p ../trimmed_aa
-for dir in aliscore_*/; do
+for dir in aliscore_output/aliscore_*/; do
     trimmed=$(find "${dir}" -name "ALICUT_*.fas")
     if [ -n "${trimmed}" ]; then
         locus=$(basename "${dir}" | sed 's/aliscore_//')
@@ -955,7 +955,7 @@ done
 
 **Understanding Outputs:**
 
-Each `aliscore_[locus]/` directory contains:
+Each `aliscore_output/aliscore_[locus]/` directory contains:
 - `*_List_random.txt` - Positions identified as RSS (input for ALICUT)
 - `*_Profile_random.txt` - Quality scores for each alignment position
 - `*.svg` - Visual plot of scoring profiles

--- a/phylo_from_buscos/scripts/run_aliscore.sh
+++ b/phylo_from_buscos/scripts/run_aliscore.sh
@@ -49,6 +49,7 @@ Usage: $0 [alignment.fas] [options]
 Run Aliscore to identify randomly similar sequence sections in alignments.
 
 Options:
+  -d DIR     Base output directory for all Aliscore results (default: aliscore_output)
   -w INT     Window size for sliding window analysis (default: 4)
   -r INT     Number of random sequence pairs to compare (default: 4*N taxa)
   -N         Treat gaps as ambiguous characters (recommended for amino acids)
@@ -62,11 +63,14 @@ Array Job Mode:
   Create locus_list.txt with: ls *.fas > locus_list.txt
 
 Examples:
-  # Basic run with defaults
+  # Basic run with defaults (outputs to aliscore_output/)
   bash run_aliscore.sh alignment.fas
 
   # Amino acid sequences with gaps as ambiguous
   bash run_aliscore.sh protein_alignment.fas -N
+
+  # Custom output directory
+  bash run_aliscore.sh alignment.fas -d my_aliscore_results
 
   # Custom window size and random pairs
   bash run_aliscore.sh alignment.fas -w 6 -r 100
@@ -78,7 +82,7 @@ Examples:
   ls aligned_aa/*.fas > locus_list.txt
   sbatch --array=1-\$(wc -l < locus_list.txt) run_aliscore_array.job
 
-Output Files:
+Output Files (in aliscore_output/aliscore_[alignment]/):
   - [alignment]_List_random.txt   : Positions identified as RSS (for ALICUT)
   - [alignment]_Profile_random.txt: Quality profile for each position
   - [alignment].svg               : Visual plot of scoring profiles
@@ -95,6 +99,7 @@ EOF
 # Parse command line arguments
 ALIGNMENT=""
 ALISCORE_OPTS=""
+BASE_OUTPUT_DIR="aliscore_output"
 
 if [ $# -eq 0 ]; then
     usage
@@ -150,6 +155,10 @@ while [ $# -gt 0 ]; do
         -h|--help)
             usage
             ;;
+        -d|--output-dir)
+            BASE_OUTPUT_DIR="$2"
+            shift 2
+            ;;
         -w)
             ALISCORE_OPTS="${ALISCORE_OPTS} -w $2"
             shift 2
@@ -189,8 +198,9 @@ done
 ALIGNMENT_NAME=$(basename "${ALIGNMENT}" .fas)
 ALIGNMENT_NAME=$(basename "${ALIGNMENT_NAME}" .fasta)
 
-# Create output directory for this alignment
-OUTPUT_DIR="aliscore_${ALIGNMENT_NAME}"
+# Create base output directory and specific directory for this alignment
+mkdir -p "${BASE_OUTPUT_DIR}"
+OUTPUT_DIR="${BASE_OUTPUT_DIR}/aliscore_${ALIGNMENT_NAME}"
 mkdir -p "${OUTPUT_DIR}"
 
 # Copy alignment to output directory

--- a/phylo_from_buscos/scripts/run_aliscore_alicut_batch.sh
+++ b/phylo_from_buscos/scripts/run_aliscore_alicut_batch.sh
@@ -33,6 +33,7 @@ Arguments:
 
 Options:
   -o DIR         Output directory for trimmed alignments (default: aliscore_alicut_trimmed)
+  -d DIR         Base directory for Aliscore outputs (default: aliscore_output)
   -w INT         Aliscore window size (default: 4)
   -r INT         Aliscore random pairs (default: 4*N)
   -N             Aliscore: treat gaps as ambiguous (recommended for AA)
@@ -52,9 +53,9 @@ Examples:
   bash run_aliscore_alicut_batch.sh aligned_rrna/ --remain-stems
 
 Output:
-  - aliscore_[locus]/          : Individual Aliscore results per locus
-  - aliscore_alicut_trimmed/   : Final trimmed alignments
-  - trimming_summary.txt       : Statistics for all loci
+  - aliscore_output/aliscore_[locus]/  : Individual Aliscore results per locus
+  - aliscore_alicut_trimmed/           : Final trimmed alignments
+  - aliscore_alicut_trimmed/trimming_summary.txt : Statistics for all loci
 
 EOF
     exit 0
@@ -63,6 +64,7 @@ EOF
 # Default parameters
 ALIGNMENT_DIR=""
 OUTPUT_DIR="aliscore_alicut_trimmed"
+ALISCORE_BASE_DIR="aliscore_output"
 ALISCORE_OPTS=""
 ALICUT_OPTS="-s"  # Silent mode by default
 
@@ -87,6 +89,10 @@ while [ $# -gt 0 ]; do
             ;;
         -o|--output)
             OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        -d|--aliscore-dir)
+            ALISCORE_BASE_DIR="$2"
             shift 2
             ;;
         -w)
@@ -170,7 +176,7 @@ for ALIGNMENT in "${ALIGNMENTS[@]}"; do
     echo ""
     echo "Step 1/2: Running Aliscore..."
 
-    if bash "${RUN_ALISCORE}" "${ALIGNMENT}" ${ALISCORE_OPTS}; then
+    if bash "${RUN_ALISCORE}" "${ALIGNMENT}" -d "${ALISCORE_BASE_DIR}" ${ALISCORE_OPTS}; then
         echo "Aliscore completed for ${LOCUS}"
     else
         echo "ERROR: Aliscore failed for ${LOCUS}"
@@ -182,7 +188,7 @@ for ALIGNMENT in "${ALIGNMENTS[@]}"; do
     echo ""
     echo "Step 2/2: Running ALICUT..."
 
-    ALISCORE_DIR="aliscore_${LOCUS}"
+    ALISCORE_DIR="${ALISCORE_BASE_DIR}/aliscore_${LOCUS}"
 
     if [ ! -d "${ALISCORE_DIR}" ]; then
         echo "ERROR: Aliscore output directory not found: ${ALISCORE_DIR}"


### PR DESCRIPTION
This commit prevents Aliscore from littering the root directory with multiple aliscore_* folders by organizing all outputs into a dedicated directory structure.

Changes:
1. run_aliscore.sh:
   - Added -d/--output-dir option to specify base output directory
   - Default base directory: aliscore_output/
   - Individual runs create: aliscore_output/aliscore_[locus]/
   - Updated usage documentation and examples

2. run_aliscore_alicut_batch.sh:
   - Added -d/--aliscore-dir option to configure base directory
   - Passes base directory to run_aliscore.sh via -d flag
   - Updated path references to use new directory structure
   - Updated output documentation

3. SKILL.md and REFERENCE.md:
   - Updated all example paths to reflect new directory structure
   - Changed aliscore_*/ references to aliscore_output/aliscore_*/
   - Updated documentation for clarity

Benefits:
- Cleaner working directory organization
- Easy to locate all Aliscore results in one place
- Maintains backward compatibility via configurable base directory
- Consistent with existing pattern (aliscore_alicut_trimmed output dir)

🤖 Generated with [Claude Code](https://claude.com/claude-code)