### PR TITLE
Fix run_alicut.sh to handle cases when only .fas files exist

### DIFF
--- a/phylo_from_buscos/scripts/run_alicut.sh
+++ b/phylo_from_buscos/scripts/run_alicut.sh
@@ -155,7 +155,7 @@ fi
 echo "Found List file: ${LIST_FILE}"
 
 # Find original FASTA file
-FASTA_FILE=$(ls *.fas *.fasta 2>/dev/null | head -n 1)
+FASTA_FILE=$(find . -maxdepth 1 \( -name "*.fas" -o -name "*.fasta" \) -type f | head -n 1 | sed 's|^\./||')
 if [ -z "${FASTA_FILE}" ]; then
     echo "ERROR: No FASTA alignment file found (*.fas or *.fasta)"
     echo "ALICUT requires the original alignment file in the same directory as List file"


### PR DESCRIPTION
The ls command at line 158 was failing when processing alignments where only .fas files (not .fasta) existed. With set -euo pipefail, this caused the script to exit before reaching the logic that handles empty List files.

Changed from:
FASTA_FILE=$(ls *.fas *.fasta 2>/dev/null | head -n 1)

To:
FASTA_FILE=$(find . -maxdepth 1 \( -name "*.fas" -o -name "*.fasta" \) -type f | head -n 1 | sed 's|^\./||')

The find command with -o (OR) doesn't exit with an error when one pattern has no matches, making it compatible with set -e. This allows the script to correctly handle alignments with no RSS positions by creating a symbolic link and exiting gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)