### PR TITLE
Enhance accounting skill with environment detection and spreadsheet confirmation

### DIFF
--- a/accounting/SKILL.md
+++ b/accounting/SKILL.md
@@ -23,7 +23,10 @@ Keywords: receipt, expense, accounting, budget, fund, supplement, p-card, procur
 
 1. **Detect year**: Determine the current year from today's date. Confirm with the user: "Working on **{year}** expenses — correct?"
 
-2. **Get spreadsheet link**: Check for `spreadsheet_links.yaml` in the working folder (`/Users/bruno/Documents/docs_macbookair2015/lab/Field Museum/accounts_and_receipts`). Regardless of whether the file exists, **always ask the user for the Google Sheet link** at the start of each session (the link may change year to year or the file may be stale). Save the link:
+2. **Get spreadsheet link**: Check for `spreadsheet_links.yaml` in the working folder (`/Users/bruno/Documents/docs_macbookair2015/lab/Field Museum/accounts_and_receipts`).
+   - If a link for this year **already exists** in the YAML, show it and ask: "Using this spreadsheet — correct? {url}"
+   - If the file is missing or has no entry for this year, ask the user for the Google Sheet link.
+   Save/update the link:
    ```yaml
    {year}:
      spreadsheet_id: "{extracted_id}"

--- a/accounting/SKILL.md
+++ b/accounting/SKILL.md
@@ -23,18 +23,34 @@ Keywords: receipt, expense, accounting, budget, fund, supplement, p-card, procur
 
 1. **Detect year**: Determine the current year from today's date. Confirm with the user: "Working on **{year}** expenses — correct?"
 
-2. **Load spreadsheet config**: Check for `spreadsheet_links.yaml` in the working folder (`/Users/bruno/Documents/docs_macbookair2015/lab/Field Museum/accounts_and_receipts`). If the file is missing or has no entry for this year, ask the user for the Google Sheet link and save it:
+2. **Get spreadsheet link**: Check for `spreadsheet_links.yaml` in the working folder (`/Users/bruno/Documents/docs_macbookair2015/lab/Field Museum/accounts_and_receipts`). Regardless of whether the file exists, **always ask the user for the Google Sheet link** at the start of each session (the link may change year to year or the file may be stale). Save the link:
    ```yaml
    {year}:
      spreadsheet_id: "{extracted_id}"
      url: "{full_url}"
    ```
 
-3. **Read current expenses**: Fetch the expenses tab via WebFetch CSV export:
-   ```
-   https://docs.google.com/spreadsheets/d/{SPREADSHEET_ID}/gviz/tq?tqx=out:csv&sheet=expenses
-   ```
-   Parse to understand existing records and the receipt numbers already used. **Analyze patterns** in existing records to learn Fund and GL code assignment conventions — e.g., which vendors consistently map to which funds and GL codes. Use these precedents when proposing values for new receipts rather than defaulting to a single fund.
+3. **Read current expenses**: Detect the environment by checking whether the working folder exists at the Mac path (use `Bash` to test). Then:
+
+   - **On cowork (local Mac — working folder exists)**:
+     Open the spreadsheet in Chrome so the user can interact with it:
+     ```bash
+     open -a "Google Chrome" "{full_url}"
+     ```
+     Also fetch the expenses tab via WebFetch CSV export:
+     ```
+     https://docs.google.com/spreadsheets/d/{SPREADSHEET_ID}/gviz/tq?tqx=out:csv&sheet=expenses
+     ```
+     If the WebFetch CSV export fails or returns an auth/login page, note this and ask the user to manually export the sheet as CSV and provide the file path.
+
+   - **Not on cowork (cloud/remote — working folder absent)**:
+     Fetch directly via WebFetch CSV export:
+     ```
+     https://docs.google.com/spreadsheets/d/{SPREADSHEET_ID}/gviz/tq?tqx=out:csv&sheet=expenses
+     ```
+     If this fails, ask the user to paste the spreadsheet data or provide a downloaded CSV file.
+
+   Parse the expenses data to understand existing records and the receipt numbers already used. **Analyze patterns** in existing records to learn Fund and GL code assignment conventions — e.g., which vendors consistently map to which funds and GL codes. Use these precedents when proposing values for new receipts rather than defaulting to a single fund.
 
 4. **Read past supplements**: List and read existing supplement PDFs in `{working_folder}/{year}/supplements/` to learn default patterns for entertainment supplement fields (Persons Involved, Business Purpose). For example, grocery store purchases may consistently use a standard lab group description while restaurant meals may list named attendees. Use these patterns as defaults when proposing supplement data for new entertainment expenses.
 


### PR DESCRIPTION
## Summary
Updated the accounting skill documentation to improve the spreadsheet handling workflow and add environment-aware behavior for fetching expense data. The changes clarify the process for confirming spreadsheet links and introduce logic to detect whether the assistant is running locally or remotely, with appropriate data-fetching strategies for each environment.

## Key Changes

- **Spreadsheet link confirmation**: Step 2 now explicitly handles two cases:
  - If a link for the year already exists in `spreadsheet_links.yaml`, display it and ask for confirmation
  - If missing or no entry exists, prompt the user to provide the link
  - Both paths save/update the YAML configuration

- **Environment detection**: Step 3 now detects the execution environment by checking if the Mac working folder exists:
  - **Local (cowork)**: Opens the spreadsheet in Chrome for user interaction AND fetches via WebFetch CSV export, with fallback instructions if export fails
  - **Remote (cloud)**: Fetches directly via WebFetch CSV export with fallback to manual CSV upload

- **Improved error handling**: Added guidance for handling WebFetch failures, including fallback options (manual CSV export on local, manual paste/upload on remote)

- **Preserved pattern analysis**: Maintained the existing requirement to analyze Fund and GL code assignment patterns from historical records and supplement PDFs

## Implementation Details
The changes maintain backward compatibility with the existing YAML configuration format while adding more explicit user confirmation steps and environment-aware behavior to handle both local and cloud execution contexts.

https://claude.ai/code/session_01QGafAxk3us6Gpit5Pa7jQa